### PR TITLE
Implement HAVING clause builder

### DIFF
--- a/.kiro/specs/select-query-builder/tasks.md
+++ b/.kiro/specs/select-query-builder/tasks.md
@@ -102,7 +102,7 @@
 
 - [ ] 7. Implement HAVING clause
 
-  - [ ] 7.1 Create HAVING clause integration with WHERE builder
+  - [x] 7.1 Create HAVING clause integration with WHERE builder
 
     - Design HAVING clause to reuse WHERE builder logic
     - Implement HavingBuilder type as extension of WhereBuilder

--- a/src/having-builder.ts
+++ b/src/having-builder.ts
@@ -1,0 +1,32 @@
+/**
+ * HavingBuilder implementation built on top of WhereBuilder
+ */
+
+import type { ConditionGroup } from "./conditions.js";
+import type { SchemaConstraint } from "./core-types.js";
+import type { ParameterManager } from "./parameter-manager.js";
+import { createWhere, createWhereWithParameters, type WhereBuilder } from "./where-builder.js";
+
+/**
+ * HavingBuilder type alias - identical to WhereBuilder
+ */
+export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T>;
+
+/**
+ * Creates a HavingBuilder with empty state
+ */
+export const createHaving = <T extends SchemaConstraint = SchemaConstraint>(): HavingBuilder<T> => {
+  return createWhere<T>();
+};
+
+/**
+ * Creates a HavingBuilder with specific state
+ * @param conditions - existing condition group
+ * @param parameters - existing parameter manager
+ */
+export const createHavingWithParameters = <T extends SchemaConstraint = SchemaConstraint>(
+  conditions: ConditionGroup,
+  parameters: ParameterManager
+): HavingBuilder<T> => {
+  return createWhereWithParameters<T>(conditions, parameters);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,9 @@ export {
   createQueryBuilderError,
   createSuccess,
 } from "./errors.js";
+// HavingBuilder - built on WhereBuilder
+export type { HavingBuilder } from "./having-builder.js";
+export { createHaving } from "./having-builder.js";
 // Parameter management
 export type { ParameterManager } from "./parameter-manager.js";
 export { addParameter, createParameterManager } from "./parameter-manager.js";

--- a/src/select-builder.ts
+++ b/src/select-builder.ts
@@ -3,6 +3,8 @@
  */
 
 import type { QueryResult, SchemaConstraint } from "./core-types.js";
+import type { HavingBuilder } from "./having-builder.js";
+import { createHaving } from "./having-builder.js";
 import type { ParameterManager } from "./parameter-manager.js";
 import { addParameter, createParameterManager } from "./parameter-manager.js";
 import type {
@@ -25,7 +27,7 @@ import {
 import { generateSelectSQL } from "./sql-generation.js";
 import { createTableReference } from "./table-utils.js";
 import type { WhereBuilder } from "./where-builder.js";
-import { createWhere, createWhereWithParameters } from "./where-builder.js";
+import { createWhereWithParameters } from "./where-builder.js";
 
 /**
  * Join condition builder function type
@@ -109,7 +111,7 @@ export type SelectQueryBuilder<T extends SchemaConstraint = SchemaConstraint> = 
 
   // Grouping methods
   groupBy<K extends keyof T>(...columns: ValidSelectColumn<T, K>[]): SelectQueryBuilder<T>;
-  having(condition: (builder: WhereBuilder<T>) => WhereBuilder<T>): SelectQueryBuilder<T>;
+  having(condition: (builder: HavingBuilder<T>) => HavingBuilder<T>): SelectQueryBuilder<T>;
 
   // Ordering methods
   orderBy<K extends keyof T>(
@@ -612,9 +614,9 @@ const createSelectWithState = <T extends SchemaConstraint = SchemaConstraint>(
       return createSelectWithState(newQuery, builder._parameters, builder._schema);
     },
 
-    having(condition: (builder: WhereBuilder<T>) => WhereBuilder<T>): SelectQueryBuilder<T> {
-      const whereBuilder = createWhere<T>();
-      const conditionBuilder = condition(whereBuilder);
+    having(condition: (builder: HavingBuilder<T>) => HavingBuilder<T>): SelectQueryBuilder<T> {
+      const havingBuilder = createHaving<T>();
+      const conditionBuilder = condition(havingBuilder);
 
       const newQuery: SelectQuery = {
         ...builder._query,

--- a/test/having-builder.test.ts
+++ b/test/having-builder.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { isConditionGroup } from "../src/conditions.js";
+import { createHaving } from "../src/having-builder.js";
+
+/** Basic tests for HavingBuilder factory */
+
+describe("HavingBuilder Factory", () => {
+  it("createHaving should return HavingBuilder instance", () => {
+    const builder = createHaving();
+    assert.ok(builder);
+    assert.ok(typeof builder.eq === "function");
+    assert.ok(typeof builder.build === "function");
+  });
+
+  it("createHaving should initialize empty state", () => {
+    const builder = createHaving();
+    assert.ok(isConditionGroup(builder._conditions));
+    assert.strictEqual(builder._conditions.conditions.length, 0);
+    assert.deepStrictEqual(builder._parameters.parameters, {});
+    assert.strictEqual(builder._parameters.counter, 0);
+  });
+
+  it("createHaving should support generic type parameter", () => {
+    interface TSchema {
+      id: number;
+      name: string;
+    }
+    const builder = createHaving<TSchema>();
+    assert.ok(builder);
+  });
+});


### PR DESCRIPTION
## Summary
- add `HavingBuilder` built on `WhereBuilder`
- use `HavingBuilder` in `SelectQueryBuilder`
- export new builder APIs
- add unit tests for `createHaving`
- mark Task 7.1 complete in spec

## Testing
- `npm run build`
- `npm run test`
- `npm run check:fix`


------
https://chatgpt.com/codex/tasks/task_e_6884180d6fb08323b944b6f81254dac3