### PR TITLE
Implement HAVING clause validation and support aggregates

### DIFF
--- a/.kiro/specs/select-query-builder/tasks.md
+++ b/.kiro/specs/select-query-builder/tasks.md
@@ -100,7 +100,7 @@
     - Write unit tests for GROUP BY functionality and validation
     - _Requirements: 4.1, 4.2, 4.4_
 
-- [ ] 7. Implement HAVING clause
+- [x] 7. Implement HAVING clause
 
   - [x] 7.1 Create HAVING clause integration with WHERE builder
 
@@ -110,7 +110,7 @@
     - Write unit tests for HAVING clause basic functionality
     - _Requirements: 5.1, 5.2_
 
-  - [ ] 7.2 Implement HAVING with aggregate function support
+  - [x] 7.2 Implement HAVING with aggregate function support
     - Enable aggregate functions in HAVING conditions
     - Implement proper validation for HAVING without GROUP BY
     - Support complex HAVING conditions with logical operators

--- a/src/having-builder.ts
+++ b/src/having-builder.ts
@@ -12,7 +12,7 @@ import { createWhere, createWhereWithParameters, type WhereBuilder } from "./whe
  */
 // Allow arbitrary expressions in HAVING by intersecting the provided schema
 // with a generic record so that any string key is permitted
-export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T>;
+export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T> & Record<string, any>;
 
 /**
  * Creates a HavingBuilder with empty state

--- a/src/having-builder.ts
+++ b/src/having-builder.ts
@@ -32,5 +32,5 @@ export const createHavingWithParameters = <T extends SchemaConstraint = SchemaCo
   conditions: ConditionGroup,
   parameters: ParameterManager
 ): HavingBuilder<T> => {
-  return createWhereWithParameters<T & SchemaConstraint>(conditions, parameters);
+  return createWhereWithParameters<T>(conditions, parameters);
 };

--- a/src/having-builder.ts
+++ b/src/having-builder.ts
@@ -12,7 +12,8 @@ import { createWhere, createWhereWithParameters, type WhereBuilder } from "./whe
  */
 // Allow arbitrary expressions in HAVING by intersecting the provided schema
 // with a generic record so that any string key is permitted
-export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T> & Record<string, any>;
+export type AggregateExpression = 'COUNT(id)' | 'SUM(amount)' | 'AVG(value)' | 'MAX(value)' | 'MIN(value)';
+export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T> & Record<AggregateExpression, any>;
 
 /**
  * Creates a HavingBuilder with empty state

--- a/src/having-builder.ts
+++ b/src/having-builder.ts
@@ -12,8 +12,7 @@ import { createWhere, createWhereWithParameters, type WhereBuilder } from "./whe
  */
 // Allow arbitrary expressions in HAVING by intersecting the provided schema
 // with a generic record so that any string key is permitted
-export type AggregateExpression = 'COUNT(id)' | 'SUM(amount)' | 'AVG(value)' | 'MAX(value)' | 'MIN(value)';
-export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T> & Record<AggregateExpression, any>;
+export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T> & Record<string, any>;
 
 /**
  * Creates a HavingBuilder with empty state

--- a/src/having-builder.ts
+++ b/src/having-builder.ts
@@ -12,16 +12,13 @@ import { createWhere, createWhereWithParameters, type WhereBuilder } from "./whe
  */
 // Allow arbitrary expressions in HAVING by intersecting the provided schema
 // with a generic record so that any string key is permitted
-export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<
-  T & SchemaConstraint
->;
+export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T>;
 
 /**
  * Creates a HavingBuilder with empty state
  */
-export const createHaving = <T extends SchemaConstraint = SchemaConstraint>(): HavingBuilder<T> => {
-  return createWhere<T & SchemaConstraint>();
-};
+export const createHaving = <T extends SchemaConstraint = SchemaConstraint>(): HavingBuilder<T> =>
+  createWhere<T>();
 
 /**
  * Creates a HavingBuilder with specific state

--- a/src/having-builder.ts
+++ b/src/having-builder.ts
@@ -10,13 +10,17 @@ import { createWhere, createWhereWithParameters, type WhereBuilder } from "./whe
 /**
  * HavingBuilder type alias - identical to WhereBuilder
  */
-export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<T>;
+// Allow arbitrary expressions in HAVING by intersecting the provided schema
+// with a generic record so that any string key is permitted
+export type HavingBuilder<T extends SchemaConstraint = SchemaConstraint> = WhereBuilder<
+  T & SchemaConstraint
+>;
 
 /**
  * Creates a HavingBuilder with empty state
  */
 export const createHaving = <T extends SchemaConstraint = SchemaConstraint>(): HavingBuilder<T> => {
-  return createWhere<T>();
+  return createWhere<T & SchemaConstraint>();
 };
 
 /**
@@ -28,5 +32,5 @@ export const createHavingWithParameters = <T extends SchemaConstraint = SchemaCo
   conditions: ConditionGroup,
   parameters: ParameterManager
 ): HavingBuilder<T> => {
-  return createWhereWithParameters<T>(conditions, parameters);
+  return createWhereWithParameters<T & SchemaConstraint>(conditions, parameters);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ export {
   setSelectDistinct,
   validateGroupByClause,
   validateGroupByColumns,
+  validateHavingClause,
   validateSelectClause,
   validateSelectColumn,
   validateSelectColumns,

--- a/src/select-builder.ts
+++ b/src/select-builder.ts
@@ -23,6 +23,7 @@ import {
   createGroupByClause,
   validateGroupByClause,
   validateGroupByColumns,
+  validateHavingClause,
 } from "./select-utils.js";
 import { generateSelectSQL } from "./sql-generation.js";
 import { createTableReference } from "./table-utils.js";
@@ -622,6 +623,15 @@ const createSelectWithState = <T extends SchemaConstraint = SchemaConstraint>(
         ...builder._query,
         having: conditionBuilder._conditions,
       };
+
+      const validation = validateHavingClause({
+        groupBy: newQuery.groupBy,
+        having: newQuery.having,
+      } as Pick<SelectQuery, "groupBy" | "having">);
+
+      if (!validation.valid) {
+        throw new Error(validation.errors.join("; "));
+      }
 
       // Merge parameters from the HAVING condition
       const newParameters = {

--- a/src/select-utils.ts
+++ b/src/select-utils.ts
@@ -340,3 +340,22 @@ export function validateGroupByColumns(query: Pick<SelectQuery, "select" | "grou
 
   return { valid: errors.length === 0, errors };
 }
+
+/**
+ * Validates HAVING clause usage
+ * Ensures HAVING is only used when GROUP BY is present
+ */
+export function validateHavingClause(query: Pick<SelectQuery, "groupBy" | "having">): {
+  valid: boolean;
+  errors: string[];
+} {
+  if (!query.having) {
+    return { valid: true, errors: [] };
+  }
+
+  if (!query.groupBy) {
+    return { valid: false, errors: ["HAVING clause requires GROUP BY"] };
+  }
+
+  return { valid: true, errors: [] };
+}

--- a/src/sql-generation.ts
+++ b/src/sql-generation.ts
@@ -433,5 +433,9 @@ export const generateSelectSQL = (query: SelectQuery): string => {
     parts.push(generateGroupByClause(query.groupBy));
   }
 
+  if (query.having && query.having.conditions.length > 0) {
+    parts.push(`HAVING ${generateConditionSql(query.having)}`);
+  }
+
   return parts.join(" ");
 };

--- a/test/having-clause.test.ts
+++ b/test/having-clause.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import type { SchemaConstraint } from "../src/core-types.js";
+import { createSelect } from "../src/select-builder.js";
+
+interface User extends SchemaConstraint {
+  id: number;
+  age: number;
+}
+
+describe("HAVING Clause", () => {
+  it("should generate GROUP BY with HAVING using aggregate", () => {
+    const result = createSelect<User>()
+      .select("age")
+      .count("id")
+      .from("users")
+      .groupBy("age")
+      .having((h) => h.gt("COUNT(id)", 1))
+      .build();
+
+    assert.strictEqual(
+      result.sql,
+      "SELECT age, COUNT(id) FROM users GROUP BY age HAVING COUNT(id) > @param1"
+    );
+    assert.deepStrictEqual(result.parameters, { param1: 1 });
+  });
+
+  it("should reject HAVING without GROUP BY", () => {
+    assert.throws(() => {
+      createSelect<User>()
+        .select("id")
+        .from("users")
+        .having((h) => h.gt("COUNT(id)", 1));
+    }, /HAVING clause requires GROUP BY/);
+  });
+
+  it("should support complex HAVING conditions", () => {
+    const result = createSelect<User>()
+      .select("age")
+      .count("id")
+      .from("users")
+      .groupBy("age")
+      .having((h) =>
+        h.and(
+          (b) => b.gt("COUNT(id)", 1),
+          (b) => b.lt("COUNT(id)", 10)
+        )
+      )
+      .build();
+
+    assert.strictEqual(
+      result.sql,
+      "SELECT age, COUNT(id) FROM users GROUP BY age HAVING (COUNT(id) > @param1 AND COUNT(id) < @param2)"
+    );
+    assert.deepStrictEqual(result.parameters, { param1: 1, param2: 10 });
+  });
+});


### PR DESCRIPTION
## Summary
- expand HavingBuilder to accept arbitrary expressions
- add HAVING validation utilities and integrate into builder
- include HAVING clause in SQL generation
- add comprehensive HAVING tests
- mark Task 7 and 7.2 complete

## Testing
- `npm run build`
- `npm run test`
- `npm run check:fix`


------
https://chatgpt.com/codex/tasks/task_e_68842138a9fc8323b62e607681511103