### PR TITLE
Implement orderBy expression support

### DIFF
--- a/.kiro/specs/select-query-builder/tasks.md
+++ b/.kiro/specs/select-query-builder/tasks.md
@@ -117,7 +117,7 @@
     - Write unit tests for aggregate conditions in HAVING
     - _Requirements: 5.2, 5.3, 5.4_
 
-- [ ] 8. Implement ORDER BY clause
+- [x] 8. Implement ORDER BY clause
 
   - [x] 8.1 Create ORDER BY types and utilities
 
@@ -127,7 +127,7 @@
     - Write unit tests for ORDER BY types and utilities
     - _Requirements: 6.1, 6.2, 6.3_
 
-  - [ ] 8.2 Implement orderBy method with multiple column support
+  - [x] 8.2 Implement orderBy method with multiple column support
     - Write orderBy method that accepts column and direction
     - Support multiple column sorting with proper precedence
     - Implement expression-based ordering support

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export {
   createGroupByClause,
   createOrderByClause,
   createOrderByColumn,
+  createOrderByExpression,
   createSelectAllClause,
   createSelectClause,
   getReferencedColumns,

--- a/src/select-builder.ts
+++ b/src/select-builder.ts
@@ -119,6 +119,7 @@ export type SelectQueryBuilder<T extends SchemaConstraint = SchemaConstraint> = 
     column: ValidSelectColumn<T, K>,
     direction?: "ASC" | "DESC"
   ): SelectQueryBuilder<T>;
+  orderByExpression(expression: string, direction?: "ASC" | "DESC"): SelectQueryBuilder<T>;
 
   // Pagination methods
   limit(count: number): SelectQueryBuilder<T>;
@@ -654,6 +655,22 @@ const createSelectWithState = <T extends SchemaConstraint = SchemaConstraint>(
         column: String(column),
         direction,
       };
+
+      const newQuery: SelectQuery = {
+        ...builder._query,
+        orderBy: {
+          columns: [...(builder._query.orderBy?.columns || []), orderByColumn],
+        },
+      };
+
+      return createSelectWithState(newQuery, builder._parameters, builder._schema);
+    },
+
+    orderByExpression(
+      expression: string,
+      direction: "ASC" | "DESC" = "ASC"
+    ): SelectQueryBuilder<T> {
+      const orderByColumn: OrderByColumn = { expression, direction };
 
       const newQuery: SelectQuery = {
         ...builder._query,

--- a/src/select-types.ts
+++ b/src/select-types.ts
@@ -77,7 +77,8 @@ export interface GroupByClause {
  * ORDER BY column specification
  */
 export interface OrderByColumn {
-  column: string;
+  column?: string;
+  expression?: string;
   direction: "ASC" | "DESC";
   nullsFirst?: boolean;
 }

--- a/src/select-utils.ts
+++ b/src/select-utils.ts
@@ -385,6 +385,21 @@ export function createOrderByColumn(
 }
 
 /**
+ * Creates an ORDER BY expression specification
+ */
+export function createOrderByExpression(
+  expression: string,
+  direction: "ASC" | "DESC" = "ASC",
+  nullsFirst?: boolean
+): OrderByColumn {
+  const result: OrderByColumn = { expression, direction };
+  if (nullsFirst !== undefined) {
+    result.nullsFirst = nullsFirst;
+  }
+  return result;
+}
+
+/**
  * Creates an ORDER BY clause from an array of columns
  */
 export function createOrderByClause(columns: OrderByColumn[]): OrderByClause {
@@ -396,8 +411,8 @@ export function createOrderByClause(columns: OrderByColumn[]): OrderByClause {
  */
 export function validateOrderByColumn(column: OrderByColumn): string[] {
   const errors: string[] = [];
-  if (!column.column) {
-    errors.push("ORDER BY column must specify a column name");
+  if (!column.column && !column.expression) {
+    errors.push("ORDER BY column must specify a column name or expression");
   }
   if (!isValidSortDirection(column.direction)) {
     errors.push(`Invalid sort direction: ${column.direction}`);

--- a/test/select-foundation.test.ts
+++ b/test/select-foundation.test.ts
@@ -262,6 +262,25 @@ describe("SELECT Query Builder Foundation", () => {
       assert.strictEqual(builder._query.orderBy.columns[0].direction, "ASC");
     });
 
+    it("should support multiple orderBy calls", () => {
+      const builder = createSelect<User>()
+        .from("users")
+        .orderBy("name", "ASC")
+        .orderBy("email", "DESC");
+
+      assert.strictEqual(builder._query.orderBy?.columns.length, 2);
+      assert.strictEqual(builder._query.orderBy?.columns[0].column, "name");
+      assert.strictEqual(builder._query.orderBy?.columns[1].column, "email");
+      assert.strictEqual(builder._query.orderBy?.columns[1].direction, "DESC");
+    });
+
+    it("should support orderBy with expressions", () => {
+      const builder = createSelect<User>().from("users").orderByExpression("LENGTH(name)", "DESC");
+
+      assert.strictEqual(builder._query.orderBy?.columns[0].expression, "LENGTH(name)");
+      assert.strictEqual(builder._query.orderBy?.columns[0].direction, "DESC");
+    });
+
     it("should support limit and offset methods", () => {
       const builder = createSelect<User>().from("users").limit(10).offset(20);
 

--- a/test/select-where-integration.test.ts
+++ b/test/select-where-integration.test.ts
@@ -197,6 +197,16 @@ describe("SELECT WHERE Integration", () => {
       assert.ok(builder._query.orderBy);
     });
 
+    it("should work with WHERE and ORDER BY expressions", () => {
+      const builder = createSelect<User>()
+        .from("users")
+        .where((w) => w.eq("active", true))
+        .orderByExpression("LENGTH(name)", "DESC");
+
+      assert.ok(builder._query.where);
+      assert.strictEqual(builder._query.orderBy?.columns[0].expression, "LENGTH(name)");
+    });
+
     it("should work with WHERE and LIMIT/OFFSET", () => {
       const builder = createSelect<User>()
         .from("users")


### PR DESCRIPTION
## Summary
- add expression field to `OrderByColumn`
- add creator for ORDER BY expressions and export from index
- support ordering by expressions via `orderByExpression`
- test ordering by multiple columns and expressions
- mark tasks 8 and 8.2 as complete

## Testing
- `npm run build`
- `npm test`
- `npm run check:fix`

------
https://chatgpt.com/codex/tasks/task_e_68846791d8808323b272e480a6ecf28e