### PR TITLE
Implement pagination validation utilities

### DIFF
--- a/.kiro/specs/select-query-builder/tasks.md
+++ b/.kiro/specs/select-query-builder/tasks.md
@@ -136,7 +136,7 @@
 
 - [ ] 9. Implement LIMIT and OFFSET clauses
 
-  - [ ] 9.1 Create pagination types and validation
+  - [x] 9.1 Create pagination types and validation
 
     - Define limit and offset value validation logic
     - Implement error handling for invalid pagination values

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,7 +17,8 @@ export type QueryBuilderErrorCode =
   | "EMPTY_CONDITIONS_ARRAY"
   | "MALFORMED_CONDITION"
   | "INVALID_TABLE_NAME"
-  | "INVALID_TABLE_ALIAS";
+  | "INVALID_TABLE_ALIAS"
+  | "INVALID_LIMIT_VALUE";
 
 /**
  * Query builder error type with structured error information

--- a/src/select-utils.ts
+++ b/src/select-utils.ts
@@ -462,7 +462,7 @@ export const validateLimitValue = (value: unknown): Result<number> => {
 export const validateOffsetValue = (value: unknown): Result<number> => {
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
     return createFailure(
-      createQueryBuilderError(`Invalid OFFSET value: ${String(value)}`, "INVALID_LIMIT_VALUE", {
+      createQueryBuilderError(`Invalid OFFSET value: ${String(value)}`, "INVALID_OFFSET_VALUE", {
         providedValue: value,
       })
     );

--- a/src/select-utils.ts
+++ b/src/select-utils.ts
@@ -3,6 +3,8 @@
  */
 
 import type { SchemaConstraint } from "./core-types.js";
+import { createFailure, createQueryBuilderError, createSuccess, type Result } from "./errors.js";
+import { addParameter, type ParameterManager } from "./parameter-manager.js";
 import {
   AGGREGATE_FUNCTIONS,
   type AggregateFunction,
@@ -439,3 +441,47 @@ export function validateOrderByClause(clause: OrderByClause): { valid: boolean; 
 
   return { valid: errors.length === 0, errors };
 }
+
+/**
+ * Validates a LIMIT value. Must be a positive integer.
+ */
+export const validateLimitValue = (value: unknown): Result<number> => {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return createFailure(
+      createQueryBuilderError(`Invalid LIMIT value: ${String(value)}`, "INVALID_LIMIT_VALUE", {
+        providedValue: value,
+      })
+    );
+  }
+  return createSuccess(value);
+};
+
+/**
+ * Validates an OFFSET value. Must be a non-negative integer.
+ */
+export const validateOffsetValue = (value: unknown): Result<number> => {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return createFailure(
+      createQueryBuilderError(`Invalid OFFSET value: ${String(value)}`, "INVALID_LIMIT_VALUE", {
+        providedValue: value,
+      })
+    );
+  }
+  return createSuccess(value);
+};
+
+/**
+ * Adds a LIMIT value as a parameter and returns the updated manager.
+ */
+export const addLimitParameter = (
+  manager: ParameterManager,
+  value: number
+): [ParameterManager, string] => addParameter(manager, value);
+
+/**
+ * Adds an OFFSET value as a parameter and returns the updated manager.
+ */
+export const addOffsetParameter = (
+  manager: ParameterManager,
+  value: number
+): [ParameterManager, string] => addParameter(manager, value);

--- a/test/pagination-validation.test.ts
+++ b/test/pagination-validation.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { createParameterManager } from "../src/parameter-manager.js";
+import {
+  addLimitParameter,
+  addOffsetParameter,
+  validateLimitValue,
+  validateOffsetValue,
+} from "../src/select-utils.js";
+
+describe("Pagination Validation", () => {
+  it("should validate limit values", () => {
+    assert.ok(validateLimitValue(1).success);
+    assert.ok(!validateLimitValue(0).success);
+    assert.ok(!validateLimitValue(-1).success);
+    assert.ok(!validateLimitValue(1.5).success);
+  });
+
+  it("should validate offset values", () => {
+    assert.ok(validateOffsetValue(0).success);
+    assert.ok(validateOffsetValue(5).success);
+    assert.ok(!validateOffsetValue(-2).success);
+    assert.ok(!validateOffsetValue(2.5).success);
+  });
+
+  it("should add pagination parameters", () => {
+    const manager = createParameterManager();
+    const [m1, limitParam] = addLimitParameter(manager, 10);
+    const [m2, offsetParam] = addOffsetParameter(m1, 5);
+
+    assert.strictEqual(limitParam, "@param1");
+    assert.strictEqual(offsetParam, "@param2");
+    assert.strictEqual(m2.parameters.param1, 10);
+    assert.strictEqual(m2.parameters.param2, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- add `INVALID_LIMIT_VALUE` error code
- implement validation helpers for LIMIT and OFFSET with parameter helpers
- add tests for pagination utilities
- check off Task 9.1 in tasks.md

## Testing
- `npm run build`
- `npm test`
- `npm run check:fix`


------
https://chatgpt.com/codex/tasks/task_e_68847d6ad7b4832381624b4cd6a0153b