### PR TITLE
Implement join options object support

### DIFF
--- a/.kiro/specs/select-query-builder/tasks.md
+++ b/.kiro/specs/select-query-builder/tasks.md
@@ -161,7 +161,7 @@
     - Write unit tests for JOIN types and utilities
     - _Requirements: 8.1, 8.2, 8.4_
 
-  - [ ] 10.2 Implement basic JOIN methods (innerJoin, leftJoin)
+  - [x] 10.2 Implement basic JOIN methods (innerJoin, leftJoin)
     - Write innerJoin method with condition builder integration
     - Implement leftJoin method with proper type handling for nullable columns
     - Support table aliases in JOIN operations

--- a/test/select-foundation.test.ts
+++ b/test/select-foundation.test.ts
@@ -197,37 +197,78 @@ describe("SELECT Query Builder Foundation", () => {
     it("should support innerJoin method", () => {
       const builder = createSelect<User>()
         .from("users")
-        .innerJoin(
-          "orders",
-          (_u, _o) =>
-            // This is a placeholder - actual join condition building will be implemented later
+        .innerJoin({
+          table: "orders",
+          alias: "o",
+          condition: (_u, _o) =>
             ({
               _conditions: { operator: "AND", conditions: [] },
               _parameters: { parameters: {}, counter: 0 },
-            }) as any
-        );
+            }) as any,
+        });
 
       assert.ok(builder);
       assert.strictEqual(builder._query.joins.length, 1);
       assert.strictEqual(builder._query.joins[0].type, "INNER");
       assert.strictEqual(builder._query.joins[0].table.name, "orders");
+      assert.strictEqual(builder._query.joins[0].table.alias, "o");
     });
 
     it("should support leftJoin method", () => {
       const builder = createSelect<User>()
         .from("users")
-        .leftJoin(
-          "orders",
-          (_u, _o) =>
+        .leftJoin({
+          table: "orders",
+          alias: "o",
+          condition: (_u, _o) =>
             ({
               _conditions: { operator: "AND", conditions: [] },
               _parameters: { parameters: {}, counter: 0 },
-            }) as any
-        );
+            }) as any,
+        });
 
       assert.ok(builder);
       assert.strictEqual(builder._query.joins.length, 1);
       assert.strictEqual(builder._query.joins[0].type, "LEFT");
+      assert.strictEqual(builder._query.joins[0].table.alias, "o");
+    });
+
+    it("should support rightJoin method", () => {
+      const builder = createSelect<User>()
+        .from("users")
+        .rightJoin({
+          table: "orders",
+          alias: "o",
+          condition: (_u, _o) =>
+            ({
+              _conditions: { operator: "AND", conditions: [] },
+              _parameters: { parameters: {}, counter: 0 },
+            }) as any,
+        });
+
+      assert.ok(builder);
+      assert.strictEqual(builder._query.joins.length, 1);
+      assert.strictEqual(builder._query.joins[0].type, "RIGHT");
+      assert.strictEqual(builder._query.joins[0].table.alias, "o");
+    });
+
+    it("should support fullJoin method", () => {
+      const builder = createSelect<User>()
+        .from("users")
+        .fullJoin({
+          table: "orders",
+          alias: "o",
+          condition: (_u, _o) =>
+            ({
+              _conditions: { operator: "AND", conditions: [] },
+              _parameters: { parameters: {}, counter: 0 },
+            }) as any,
+        });
+
+      assert.ok(builder);
+      assert.strictEqual(builder._query.joins.length, 1);
+      assert.strictEqual(builder._query.joins[0].type, "FULL");
+      assert.strictEqual(builder._query.joins[0].table.alias, "o");
     });
   });
 

--- a/test/select-where-integration.test.ts
+++ b/test/select-where-integration.test.ts
@@ -245,7 +245,10 @@ describe("SELECT WHERE Integration", () => {
     it("should integrate WHERE with INNER JOIN", () => {
       const builder = createSelect<User>()
         .from("users")
-        .innerJoin("orders", (_u, _o) => createWhere().eq("id", 1))
+        .innerJoin({
+          table: "orders",
+          condition: (_u, _o) => createWhere().eq("id", 1),
+        })
         .where((w) => w.eq("active", true));
 
       assert.ok(builder._query.joins);
@@ -262,7 +265,10 @@ describe("SELECT WHERE Integration", () => {
 
       const builder = createSelect<User>()
         .from("users")
-        .innerJoin("orders", (_u, _o) => createWhere<User & Order>().eq("user_id", 1))
+        .innerJoin({
+          table: "orders",
+          condition: (_u, _o) => createWhere<User & Order>().eq("user_id", 1),
+        })
         .where((w) => w.eq("active", true).gt("age", 18));
 
       const result = builder.build();


### PR DESCRIPTION
## Summary
- define `JoinOptions` type for join methods
- use `JoinOptions` across all join overloads

## Testing
- `npm run build`
- `npm test`
- `npm run check:fix` *(with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6884df3e9b2883239df92fe6bfba0ca6