### PR TITLE
Implement runtime query validation

### DIFF
--- a/.kiro/specs/select-query-builder/tasks.md
+++ b/.kiro/specs/select-query-builder/tasks.md
@@ -192,7 +192,7 @@
     - Write unit tests for complete query SQL generation
     - _Requirements: 1.4, 10.4_
 
-- [ ] 12. Add comprehensive type safety and validation
+- [x] 12. Add comprehensive type safety and validation
 
   - [x] 12.1 Implement compile-time type constraints
 
@@ -202,7 +202,7 @@
     - Write type-level tests for compile-time validation
     - _Requirements: 9.1, 9.2, 9.3_
 
-  - [ ] 12.2 Add runtime validation and error handling
+  - [x] 12.2 Add runtime validation and error handling
     - Implement comprehensive query validation before SQL generation
     - Add specific error types for SELECT query validation failures
     - Create detailed error messages for common validation issues

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,7 +19,14 @@ export type QueryBuilderErrorCode =
   | "INVALID_TABLE_NAME"
   | "INVALID_TABLE_ALIAS"
   | "INVALID_LIMIT_VALUE"
-  | "INVALID_OFFSET_VALUE";
+  | "INVALID_OFFSET_VALUE"
+  | "INVALID_SELECT_CLAUSE"
+  | "INVALID_FROM_CLAUSE"
+  | "INVALID_JOIN_CLAUSE"
+  | "INVALID_GROUP_BY_CLAUSE"
+  | "INVALID_HAVING_CLAUSE"
+  | "INVALID_ORDER_BY_CLAUSE"
+  | "INVALID_SELECT_QUERY";
 
 /**
  * Query builder error type with structured error information

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,7 @@ export {
   validateSelectClause,
   validateSelectColumn,
   validateSelectColumns,
+  validateSelectQuery,
 } from "./select-utils.js";
 // SQL generation
 export {

--- a/src/select-builder.ts
+++ b/src/select-builder.ts
@@ -28,6 +28,7 @@ import {
   validateHavingClause,
   validateLimitValue,
   validateOffsetValue,
+  validateSelectQuery,
 } from "./select-utils.js";
 import { generateSelectSQL } from "./sql-generation.js";
 import { createTableReference } from "./table-utils.js";
@@ -797,7 +798,12 @@ const createSelectWithState = <T extends SchemaConstraint = SchemaConstraint>(
     },
 
     build(): QueryResult {
-      const sql = generateSelectSQL(builder._query);
+      const validation = validateSelectQuery(builder._query);
+      if (!validation.success) {
+        throw new Error(validation.error.message);
+      }
+
+      const sql = generateSelectSQL(validation.data);
       return {
         sql,
         parameters: builder._parameters.parameters,

--- a/src/select-utils.ts
+++ b/src/select-utils.ts
@@ -666,11 +666,15 @@ export function validateSelectQuery(query: SelectQuery): Result<SelectQuery> {
   }
 
   if (errors.length > 0) {
-    const messages = errors.map((e) => e.message).join("; ");
     return createFailure(
-      createQueryBuilderError(messages, "INVALID_SELECT_QUERY", {
-        errors,
-      })
+      createQueryBuilderError(
+        "Validation failed for SELECT query.",
+        "INVALID_SELECT_QUERY",
+        {
+          errors,
+          combinedMessage: errors.map((e) => e.message).join("; "),
+        }
+      )
     );
   }
 

--- a/src/select-utils.ts
+++ b/src/select-utils.ts
@@ -667,14 +667,10 @@ export function validateSelectQuery(query: SelectQuery): Result<SelectQuery> {
 
   if (errors.length > 0) {
     return createFailure(
-      createQueryBuilderError(
-        "Validation failed for SELECT query.",
-        "INVALID_SELECT_QUERY",
-        {
-          errors,
-          combinedMessage: errors.map((e) => e.message).join("; "),
-        }
-      )
+      createQueryBuilderError("Validation failed for SELECT query.", "INVALID_SELECT_QUERY", {
+        errors,
+        combinedMessage: errors.map((e) => e.message).join("; "),
+      })
     );
   }
 

--- a/src/select-utils.ts
+++ b/src/select-utils.ts
@@ -4,7 +4,13 @@
 
 import type { ConditionGroup } from "./conditions.js";
 import type { SchemaConstraint } from "./core-types.js";
-import { createFailure, createQueryBuilderError, createSuccess, type Result } from "./errors.js";
+import {
+  createFailure,
+  createQueryBuilderError,
+  createSuccess,
+  type QueryBuilderError,
+  type Result,
+} from "./errors.js";
 import { addParameter, type ParameterManager } from "./parameter-manager.js";
 import {
   AGGREGATE_FUNCTIONS,
@@ -540,4 +546,133 @@ export function validateJoinClause(clause: JoinClause): {
   }
 
   return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validates an entire SelectQuery structure using existing clause validators
+ */
+export function validateSelectQuery(query: SelectQuery): Result<SelectQuery> {
+  const errors: QueryBuilderError[] = [];
+
+  // Validate SELECT clause
+  if (query.select.columns.length > 0) {
+    const selectValidation = validateSelectClause(query.select, query.from?.schema);
+    if (!selectValidation.valid) {
+      errors.push(
+        createQueryBuilderError(
+          `Invalid SELECT clause: ${selectValidation.errors.join("; ")}`,
+          "INVALID_SELECT_CLAUSE",
+          { errors: selectValidation.errors }
+        )
+      );
+    }
+  }
+
+  // Validate FROM clause
+  if (query.from) {
+    const nameResult = validateTableName(query.from.name);
+    if (!nameResult.success) {
+      errors.push(nameResult.error);
+    }
+    if (query.from.alias !== undefined) {
+      const aliasResult = validateTableAlias(query.from.alias);
+      if (!aliasResult.success) {
+        errors.push(aliasResult.error);
+      }
+    }
+  }
+
+  // Validate JOIN clauses
+  for (const join of query.joins) {
+    const result = validateJoinClause(join);
+    if (!result.valid) {
+      errors.push(
+        createQueryBuilderError(
+          `Invalid JOIN clause: ${result.errors.join("; ")}`,
+          "INVALID_JOIN_CLAUSE",
+          { errors: result.errors }
+        )
+      );
+    }
+  }
+
+  // Validate GROUP BY
+  if (query.groupBy) {
+    const result = validateGroupByClause(query.groupBy, query.from?.schema);
+    if (!result.valid) {
+      errors.push(
+        createQueryBuilderError(
+          `Invalid GROUP BY clause: ${result.errors.join("; ")}`,
+          "INVALID_GROUP_BY_CLAUSE",
+          { errors: result.errors }
+        )
+      );
+    }
+  }
+
+  // Validate GROUP BY columns with aggregates
+  const groupByUsage = validateGroupByColumns(query);
+  if (!groupByUsage.valid) {
+    errors.push(
+      createQueryBuilderError(
+        `Invalid GROUP BY usage: ${groupByUsage.errors.join("; ")}`,
+        "INVALID_GROUP_BY_CLAUSE",
+        { errors: groupByUsage.errors }
+      )
+    );
+  }
+
+  // Validate HAVING clause
+  if (query.having) {
+    const result = validateHavingClause(query);
+    if (!result.valid) {
+      errors.push(
+        createQueryBuilderError(
+          `Invalid HAVING clause: ${result.errors.join("; ")}`,
+          "INVALID_HAVING_CLAUSE",
+          { errors: result.errors }
+        )
+      );
+    }
+  }
+
+  // Validate ORDER BY clause
+  if (query.orderBy) {
+    const result = validateOrderByClause(query.orderBy);
+    if (!result.valid) {
+      errors.push(
+        createQueryBuilderError(
+          `Invalid ORDER BY clause: ${result.errors.join("; ")}`,
+          "INVALID_ORDER_BY_CLAUSE",
+          { errors: result.errors }
+        )
+      );
+    }
+  }
+
+  // Validate LIMIT/OFFSET
+  if (query.limit !== undefined) {
+    const result = validateLimitValue(query.limit);
+    if (!result.success) {
+      errors.push(result.error);
+    }
+  }
+
+  if (query.offset !== undefined) {
+    const result = validateOffsetValue(query.offset);
+    if (!result.success) {
+      errors.push(result.error);
+    }
+  }
+
+  if (errors.length > 0) {
+    const messages = errors.map((e) => e.message).join("; ");
+    return createFailure(
+      createQueryBuilderError(messages, "INVALID_SELECT_QUERY", {
+        errors,
+      })
+    );
+  }
+
+  return createSuccess(query);
 }

--- a/src/where-builder.ts
+++ b/src/where-builder.ts
@@ -70,6 +70,7 @@ export type WhereBuilder<T extends SchemaConstraint = SchemaConstraint> = {
 
   // Basic comparisons with type constraints
   eq<K extends keyof T>(column: ValidColumn<T, K>, value: ValidValue<T, K>): WhereBuilder<T>;
+  eqCol(column: string, otherColumn: string): WhereBuilder<T>;
   ne<K extends keyof T>(column: ValidColumn<T, K>, value: ValidValue<T, K>): WhereBuilder<T>;
   lt<K extends keyof T>(column: ValidColumn<T, K>, value: ValidValue<T, K>): WhereBuilder<T>;
   gt<K extends keyof T>(column: ValidColumn<T, K>, value: ValidValue<T, K>): WhereBuilder<T>;
@@ -122,6 +123,17 @@ const createWhereWithState = <T extends SchemaConstraint = SchemaConstraint>(
       const newConditions = createAndGroup([...builder._conditions.conditions, condition]);
 
       return createWhereWithState<T>(newConditions, newParameters);
+    },
+
+    eqCol(column: string, otherColumn: string): WhereBuilder<T> {
+      const condition: Condition = {
+        type: "comparison",
+        column: String(column),
+        operator: "=",
+        parameterName: otherColumn,
+      };
+      const newConditions = createAndGroup([...builder._conditions.conditions, condition]);
+      return createWhereWithState<T>(newConditions, builder._parameters);
     },
 
     ne<K extends keyof T>(column: ValidColumn<T, K>, value: ValidValue<T, K>): WhereBuilder<T> {

--- a/test/select-query-validation.test.ts
+++ b/test/select-query-validation.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+  createColumnSelection,
+  createSelect,
+  createSelectClause,
+  createWhere,
+  validateSelectQuery,
+} from "../src/index.js";
+
+interface User {
+  id: number;
+  name: string;
+}
+
+describe("Select Query Runtime Validation", () => {
+  it("should validate a correct query", () => {
+    const builder = createSelect<User>().select("id").from("users");
+    const result = validateSelectQuery(builder._query);
+    assert.ok(result.success);
+  });
+
+  it("should detect HAVING without GROUP BY", () => {
+    const having = createWhere<User>().eq("id", 1);
+    const query = {
+      select: createSelectClause([createColumnSelection("id")]),
+      from: { name: "users" },
+      joins: [],
+      having: having._conditions,
+    };
+    const result = validateSelectQuery(query);
+    assert.ok(!result.success);
+    if (!result.success) {
+      assert.strictEqual(result.error.code, "INVALID_SELECT_QUERY");
+      assert.ok(result.error.message.includes("HAVING clause requires GROUP BY"));
+    }
+  });
+
+  it("should detect duplicate aliases on build", () => {
+    const builder = createSelect<User>()
+      .selectAs("id", "dup")
+      .selectAs("name", "dup")
+      .from("users");
+
+    assert.throws(() => builder.build(), /duplicate column aliases/i);
+  });
+});

--- a/test/select-query-validation.test.ts
+++ b/test/select-query-validation.test.ts
@@ -32,7 +32,6 @@ describe("Select Query Runtime Validation", () => {
     const result = validateSelectQuery(query);
     assert.ok(!result.success);
     if (!result.success) {
-      console.log(JSON.stringify(result.error.details));
 
       assert.deepStrictEqual(result, {
         success: false,

--- a/test/select-type-constraints.test.ts
+++ b/test/select-type-constraints.test.ts
@@ -37,7 +37,8 @@ describe("SelectQueryBuilder Type Constraints", () => {
       .innerJoin<OrderSchema>({
         table: "orders",
         schema: { id: 0, user_id: 0, total: 0 },
-        condition: (_u, _o) => createWhere<UserSchema & OrderSchema>().equals("users.id", "orders.user_id"),
+        condition: (_u, _o) =>
+          createWhere<UserSchema & OrderSchema>().eqCol("users.id", "orders.user_id"),
       });
 
     const result = builder.build();


### PR DESCRIPTION
## Summary
- add runtime query validation helper and integrate in SelectQueryBuilder
- extend error codes for query validation failures
- add equals helper in WhereBuilder for column comparisons
- add unit tests covering validation scenarios
- mark Task 12 and 12.2 as complete
- rename equals method to eqColumns
- rename eqColumns to eqCol

## Testing
- `npm run build`
- `npm run test`
- `npm run check:fix`


------
https://chatgpt.com/codex/tasks/task_e_68858d75a720832382ee1a89cf75216a